### PR TITLE
Responsive design for mobiles fixes

### DIFF
--- a/site/css/style.css
+++ b/site/css/style.css
@@ -5877,11 +5877,14 @@ kbd {
     align-items: center;
     padding: 0.35rem 0.5rem;
     border-bottom: 1px solid var(--border);
+    flex-wrap: wrap;
+    gap: 0.25rem;
 }
 .build-stats-header-actions {
     display: flex;
     gap: 0.25rem;
     align-items: center;
+    flex-wrap: wrap;
 }
 .build-expand-all-btn {
     background: none;
@@ -6161,6 +6164,8 @@ kbd {
     align-items: center;
     padding: 0.35rem 0.5rem;
     border-bottom: 1px solid var(--border);
+    flex-wrap: wrap;
+    gap: 0.25rem;
 }
 .build-inventory-sort-btn {
     display: flex;
@@ -6337,6 +6342,7 @@ kbd {
     grid-column: 1 / -1;
     display: flex;
     gap: 4px;
+    flex-wrap: wrap;
 }
 .build-weapon-toggle-btn {
     padding: 0.2rem 0.6rem;

--- a/site/css/style.css
+++ b/site/css/style.css
@@ -1498,6 +1498,16 @@ a.tile-card-name:hover {
 .settings-wrap {
     position: relative;
 }
+/* Filter-bar mobile settings button: hidden on desktop (nav-bar has it there) */
+.filter-bar-settings-btn {
+    display: none;
+}
+/* Backdrop for the Teleported filter-bar settings panel */
+.filter-bar-settings-backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 200;
+}
 .settings-btn {
     display: inline-flex;
     align-items: center;
@@ -4249,6 +4259,10 @@ kbd {
         pointer-events: auto;
     }
     .nav-bar .settings-wrap .settings-menu { right: 0.25rem; }
+    /* On mobile the settings icon moves into the filter-bar; hide it from the nav-bar */
+    .nav-bar .settings-wrap { display: none; }
+    /* Show the filter-bar settings button only on mobile */
+    .filter-bar-settings-btn { display: inline-flex; }
 
     /* What's New banner: center horizontally */
     .whats-new-banner { left: 0.75rem; right: 0.75rem; width: auto; max-width: none; }

--- a/site/js/app.js
+++ b/site/js/app.js
@@ -6805,65 +6805,6 @@ export const appDefinition = {
             }
         });
 
-        // Touch swipe gesture: swipe left/right to cycle nav tabs (mobile/tablet)
-        {
-            const NAV_TABS = ['db', 'crafting', 'build-planner', 'ballistics', 'maps', 'trading'];
-            let swipeTouchStartX = 0;
-            let swipeTouchStartY = 0;
-            let swipeTouchStartTarget = null;
-
-            const SWIPE_MIN_X = 70;       // minimum horizontal distance in px
-            const SWIPE_RATIO = 1.5;      // horizontal must be at least 1.5× vertical
-
-            const isModalOpen = () =>
-                this.modalOpen || this.quickNavOpen || this.buildPickerOpen ||
-                this.buildSaveModalOpen || this.buildImportCodeModalOpen ||
-                this.saveImportModalOpen || this.shortcutHelpOpen || this.weaponMechanicsOpen;
-
-            const onTouchStart = (e) => {
-                swipeTouchStartX = e.touches[0].clientX;
-                swipeTouchStartY = e.touches[0].clientY;
-                swipeTouchStartTarget = e.target;
-            };
-
-            const onTouchEnd = (e) => {
-                if (isModalOpen()) return;
-                // Block if the swipe started inside the sidebar, header, or any overlay
-                if (swipeTouchStartTarget?.closest(
-                    '.sidebar, .site-header, .nav-bar, .modal, .modal-backdrop, ' +
-                    '.header-drawer, .header-drawer-backdrop, .mobile-search-overlay'
-                )) return;
-
-                const dx = e.changedTouches[0].clientX - swipeTouchStartX;
-                const dy = e.changedTouches[0].clientY - swipeTouchStartY;
-
-                if (Math.abs(dx) < SWIPE_MIN_X) return;
-                if (Math.abs(dx) < Math.abs(dy) * SWIPE_RATIO) return;
-
-                let current;
-                if (this.tradingActive)          current = 'trading';
-                else if (this.mapsActive)         current = 'maps';
-                else if (this.damageSimActive)    current = 'ballistics';
-                else if (this.buildPlannerActive) current = 'build-planner';
-                else if (this.isCrafting)         current = 'crafting';
-                else                              current = 'db';
-
-                const idx = NAV_TABS.indexOf(current);
-                // swipe left (dx < 0) → next tab; swipe right (dx > 0) → prev tab
-                const direction = dx < 0 ? 1 : -1;
-                const next = NAV_TABS[(idx + direction + NAV_TABS.length) % NAV_TABS.length];
-
-                if (next === 'db')             this.openItemDb();
-                else if (next === 'crafting')  this.openCrafting();
-                else if (next === 'build-planner') this.openBuildPlanner();
-                else if (next === 'ballistics')    this.openDamageSim();
-                else if (next === 'maps')          this.openMaps();
-                else if (next === 'trading')        this.openTrading();
-            };
-
-            document.addEventListener('touchstart', onTouchStart, { passive: true });
-            document.addEventListener('touchend',   onTouchEnd,   { passive: true });
-        }
 
         // 0. Backward-compat: redirect legacy query-param URLs to path-based URLs
         // Pack-dependent paths (db categories, favorites, recent) are redirected later

--- a/site/src/components/DamageSimulator.vue
+++ b/site/src/components/DamageSimulator.vue
@@ -1960,4 +1960,75 @@ export default defineComponent({
   font-size: 0.75rem;
   margin: 0;
 }
+
+/* ── Mobile / small-screen fixes ────────────────────────────────────────── */
+@media (max-width: 768px) {
+  .damage-sim {
+    padding-right: 0.5rem;
+    /* do NOT add overflow-x: hidden – that clips content instead of fitting it */
+  }
+
+  /* KEY FIX: grid items must have min-width: 0 so they respect their track
+     width and don't push the column (and the page) wider than the viewport. */
+  .damage-sim-panel {
+    min-width: 0;
+  }
+
+  /* Topbar: allow credit + actions to wrap on tiny screens */
+  .damage-sim-topbar {
+    flex-wrap: wrap;
+    gap: 0.4rem;
+  }
+  .damage-sim-actions {
+    flex-wrap: wrap;
+  }
+
+  /* ── Toggle groups ────────────────────────────────────────────────────── *
+   * Buttons default to min-width:auto which means they refuse to shrink     *
+   * below their text content.  6 faction buttons × ~68 px = ~408 px on a   *
+   * 375 px screen → overflow.  Fix: drop the shared-border approach, give  *
+   * every button its own border and let the group wrap freely.              */
+  .damage-sim-toggle-group {
+    flex-wrap: wrap;
+    overflow: visible;
+    border: none;           /* outer border replaced by per-button borders   */
+    gap: 0.3rem;
+  }
+  .damage-sim-toggle-group button {
+    flex: 1 1 auto;
+    min-width: 0;           /* allow shrinking below content width           */
+    border: 1px solid var(--border) !important;
+    border-radius: 3px !important;
+  }
+  .damage-sim-toggle-group button + button {
+    border-left: 1px solid var(--border) !important;
+  }
+  .damage-sim-toggle-group button.active {
+    border-color: var(--accent-dim) !important;
+  }
+
+  /* ── Loadout row ──────────────────────────────────────────────────────── *
+   * Allow wrapping so weapon + ammo slots stack on very narrow screens.     *
+   * The slots already have flex:1 + min-width:0 + text-overflow:ellipsis   *
+   * so on most 375 px+ screens they stay on one row and just truncate.      */
+  .damage-sim-loadout-row {
+    flex-wrap: wrap;
+    row-gap: 0.25rem;
+  }
+  .damage-sim-loadout-row > .damage-sim-slot {
+    /* each slot can claim a full row on its own when space is too tight */
+    flex: 1 1 8rem;
+    min-width: 0;
+  }
+
+  /* ── Slot meta text ───────────────────────────────────────────────────── *
+   * "Body X · Head X · AP Scale X · Hit Frac X" – very long, no wrapping.  */
+  .damage-sim-slot-meta {
+    white-space: normal;
+    overflow-wrap: break-word;
+    word-break: break-word;
+    font-size: 0.55rem;
+    line-height: 1.4;
+  }
+}
 </style>

--- a/site/src/components/FilterBar.vue
+++ b/site/src/components/FilterBar.vue
@@ -190,6 +190,39 @@
                 <button v-if="isWeaponSection" class="weapon-help-btn" @click="$emit('openWeaponHelp')" v-tooltip="t('app_label_weapon_mechanics_help')">
                     <LucideInfo :size="16" />
                 </button>
+                <!-- Mobile-only settings button: hidden on desktop (nav-bar has settings there).
+                     Only shown on Items tab (not crafting, not outfit exchange).        -->
+                <button
+                    v-if="!isCrafting && !isOutfitExchange"
+                    class="settings-btn filter-bar-settings-btn"
+                    @click.stop="openSettings($event)"
+                    v-tooltip="t('app_label_settings')">
+                    <LucideSettings :size="16" />
+                </button>
+                <!-- Settings panel – Teleported to <body> so it escapes overflow:hidden ancestors -->
+                <Teleport to="body">
+                    <!-- Invisible backdrop: catches outside clicks to close -->
+                    <div v-if="settingsOpen" class="filter-bar-settings-backdrop" @click="closeSettings()"></div>
+                    <!-- Panel positioned via fixed coords computed on open -->
+                    <div v-if="settingsOpen"
+                         class="settings-menu filter-bar-settings-panel"
+                         :style="{ position: 'fixed', top: _settingsPos.top + 'px', right: _settingsPos.right + 'px', zIndex: 201 }"
+                         @click.stop>
+                        <div class="settings-header">{{ t('app_label_display') }}</div>
+                        <div class="settings-item" @click.stop="$emit('toggleHideNoDrop')">
+                            <span class="toggle-switch" :class="{ on: hideNoDrop }"><span class="toggle-knob"></span></span>
+                            <span>{{ t('app_label_hide_no_drop') }}</span>
+                        </div>
+                        <div class="settings-item" @click.stop="$emit('toggleHideUnusedAmmo')">
+                            <span class="toggle-switch" :class="{ on: hideUnusedAmmo }"><span class="toggle-knob"></span></span>
+                            <span>{{ t('app_label_hide_unused_ammo') }}</span>
+                        </div>
+                        <div class="settings-item" @click.stop="$emit('toggleShowTileIcons')">
+                            <span class="toggle-switch" :class="{ on: showTileIcons }"><span class="toggle-knob"></span></span>
+                            <span>{{ t('app_label_show_tile_icons') }}</span>
+                        </div>
+                    </div>
+                </Teleport>
                 <div class="view-toggle" v-show="!favoritesViewActive && !recentViewActive && !isOutfitExchange && !isCrafting && !isToolkitRates">
                     <button :class="{ active: viewMode === 'table' }" @click="$emit('setViewMode', 'table')" v-tooltip="t('app_label_table_view')">
                         <LucideList :size="16" />
@@ -258,6 +291,7 @@ export default {
         filteredExchanges: { type: Array, default: () => [] },
         hideNoDrop: { type: Boolean, default: false },
         hideUnusedAmmo: { type: Boolean, default: false },
+        showTileIcons: { type: Boolean, default: true },
         toolkitRates: { type: Object, default: null },
         toolkitSortCol: { type: String, default: '' },
         toolkitSortAsc: { type: Boolean, default: true },
@@ -287,6 +321,7 @@ export default {
         'downloadData',
         'toggleHideNoDrop',
         'toggleHideUnusedAmmo',
+        'toggleShowTileIcons',
         'openWeaponHelp',
     ],
     data() {
@@ -296,6 +331,7 @@ export default {
             downloadMenuOpen: false,
             settingsOpen: false,
             _filterPanelCleanup: null,
+            _settingsPos: { top: 0, right: 0 },
         };
     },
     methods: {
@@ -362,6 +398,16 @@ export default {
         },
         closeSettings() {
             this.settingsOpen = false;
+        },
+        openSettings(event) {
+            if (this.settingsOpen) { this.closeSettings(); return; }
+            const btn = event.currentTarget;
+            const rect = btn.getBoundingClientRect();
+            this._settingsPos = {
+                top: rect.bottom + 4,
+                right: window.innerWidth - rect.right,
+            };
+            this.settingsOpen = true;
         },
         onPickSort(col) {
             this.sortMenuOpen = false;

--- a/site/src/components/modals/ShortcutHelpModal.vue
+++ b/site/src/components/modals/ShortcutHelpModal.vue
@@ -13,7 +13,6 @@
                     <dl class="shortcut-list">
                         <div class="shortcut-row shortcut-row--highlight"><dt><kbd>Ctrl</kbd> <kbd>K</kbd></dt><dd>{{ t('app_shortcuts_quick_nav') }}</dd></div>
                         <div class="shortcut-row shortcut-row--highlight"><dt><kbd>Alt</kbd> <kbd>←</kbd> / <kbd>→</kbd></dt><dd>{{ t('app_shortcuts_nav_tabs') }}</dd></div>
-                        <div class="shortcut-row shortcut-row--touch shortcut-row--highlight shortcut-row--touch-highlight"><dt><svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="flex-shrink:0"><path d="M18 11V6a2 2 0 0 0-2-2a2 2 0 0 0-2 2"/><path d="M14 10V4a2 2 0 0 0-2-2a2 2 0 0 0-2 2v2"/><path d="M10 10.5a2 2 0 0 0-2-2a2 2 0 0 0-2 2V17a6 6 0 0 0 6 6h2a6 6 0 0 0 6-6V9a2 2 0 0 0-2-2a2 2 0 0 0-2 2"/><path d="m7 15-1.8-1.8a2 2 0 0 0-2.8 2.8L5 18.8"/></svg> ← / →</dt><dd>{{ t('app_shortcuts_swipe_tabs') }}</dd></div>
                         <div class="shortcut-row"><dt><kbd>/</kbd> <span class="shortcut-or">{{ t('app_shortcuts_or') }}</span> <kbd>S</kbd></dt><dd>{{ t('app_shortcuts_search') }}</dd></div>
                         <div class="shortcut-row"><dt><kbd>B</kbd></dt><dd>{{ t('app_shortcuts_toggle_sidebar') }}</dd></div>
                         <div class="shortcut-row"><dt><kbd>V</kbd></dt><dd>{{ t('app_shortcuts_toggle_view') }}</dd></div>


### PR DESCRIPTION
- swipe right/left on tablet/mobiles devices had to be turned off since when user wanted to scroll on for example 'Crafting Tree' it was scrolling whole tab - reported by @akzar that it was anoying _(swipe removed from keyboard shortcuts)_
- '_Build Planner_' tab had some elements which were not wrapped and user either had to scroll to right or it was not possible to scroll at all so the data was not visible _(screen 1 and 2)_
- '_Ballistics_'  tab was not prepared for mobile devices at all, whole content had user scroll to right to see all. Now it fits the width of the screen. There're still small problems with table on bottom where numbers like `0.12345` are overlaping each other, but now it's better at least overall _(screen 3)_.
- '_Settings_' btn was not working on mobile devices, it just showed tooltip. Now it's fixed and only on mobiles moved into filter-bar section, not in same div as tabs - **more space for tabs scroll now**. Since it's used only for 'Items' it remained only there, not in other tabs _(screen 4)_.

<img width="300"  alt="bug-2" src="https://github.com/user-attachments/assets/62562c5d-fdcd-4ef2-be48-21b29daa9943" />
<img width="300"  alt="bug-1" src="https://github.com/user-attachments/assets/51dd7c07-2eff-4c14-a702-cb6fd56f8745" />
<img width="300"  alt="image" src="https://github.com/user-attachments/assets/ed838be2-da31-4fb3-8dfb-916b3ae24a32" />
<img width="200" alt="image" src="https://github.com/user-attachments/assets/59462a8c-a9fa-4526-8899-b8da56f661f7" />


